### PR TITLE
Replace fmt.Errorf with errors.New in tests across modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.17 AS builder
+FROM golang:1.24-alpine3.21 AS builder
 ENV GO111MODULE=on
 WORKDIR /build
 COPY . .
@@ -7,7 +7,7 @@ RUN apk add --no-cache git make \
     && make build
 
 ###
-FROM alpine:3.17 AS dist
+FROM alpine:2117 AS dist
 ENV MIGRATION_SOURCE_URL=./migrations
 
 RUN mkdir /app && addgroup -S golauth && adduser -S golauth -G golauth \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golauth/golauth
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/cristalhq/jwt/v3 v3.1.0

--- a/src/application/role/AddRole_test.go
+++ b/src/application/role/AddRole_test.go
@@ -2,7 +2,7 @@ package role
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"github.com/golauth/golauth/src/domain/entity"
 	factoryMock "github.com/golauth/golauth/src/domain/factory/mock"
 	"github.com/golauth/golauth/src/domain/repository/mock"
@@ -70,7 +70,7 @@ func (s *AddRoleSuite) TestCreateNotOk() {
 		Name:        "NEW_ROLE",
 		Description: "New Role",
 	}
-	s.repo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf(errMessage)).Times(1)
+	s.repo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil, errors.New(errMessage)).Times(1)
 	resp, err := s.addRole.Execute(context.Background(), input)
 	s.Error(err)
 	s.Zero(resp)

--- a/src/application/role/EditRole_test.go
+++ b/src/application/role/EditRole_test.go
@@ -2,6 +2,7 @@ package role
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/golauth/golauth/src/domain/entity"
 	"github.com/golauth/golauth/src/domain/repository/mock"
@@ -72,7 +73,7 @@ func (s *EditRoleSuite) TestEditExistsErr() {
 		Name:        "NEW_ROLE",
 		Description: "Edited Role",
 	}
-	s.repo.EXPECT().ExistsById(s.ctx, roleId).Return(false, fmt.Errorf(errMessage)).Times(1)
+	s.repo.EXPECT().ExistsById(s.ctx, roleId).Return(false, errors.New(errMessage)).Times(1)
 	err := s.editRole.Execute(s.ctx, roleId, input)
 	s.Error(err)
 	s.EqualError(err, errMessage)

--- a/src/application/role/FindRoleByName_test.go
+++ b/src/application/role/FindRoleByName_test.go
@@ -2,7 +2,7 @@ package role
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"github.com/golauth/golauth/src/domain/entity"
 	"github.com/golauth/golauth/src/domain/repository/mock"
 	"github.com/google/uuid"
@@ -69,7 +69,7 @@ func (s *FindRoleByNameSuite) TestFindByNameNotOk() {
 		CreationDate: time.Now(),
 	}
 	errMessage := "could not find role by name"
-	s.repo.EXPECT().FindByName(s.ctx, "ROLE").Return(nil, fmt.Errorf(errMessage)).Times(1)
+	s.repo.EXPECT().FindByName(s.ctx, "ROLE").Return(nil, errors.New(errMessage)).Times(1)
 	resp, err := s.finding.Execute(s.ctx, role.Name)
 	s.Error(err)
 	s.EqualError(err, errMessage)

--- a/src/infra/api/controller/RoleController_test.go
+++ b/src/infra/api/controller/RoleController_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/gofiber/fiber/v2"
 	"github.com/golauth/golauth/src/domain/entity"
@@ -124,7 +125,7 @@ func (s *RoleControllerSuite) TestEditRoleNotOk() {
 	r.Header.Set("Content-Type", "application/json")
 
 	s.roleRepo.EXPECT().ExistsById(r.Context(), roleId).Return(true, nil).Times(1)
-	s.roleRepo.EXPECT().Edit(r.Context(), gomock.Any()).Return(fmt.Errorf(errMessage)).Times(1)
+	s.roleRepo.EXPECT().Edit(r.Context(), gomock.Any()).Return(errors.New(errMessage)).Times(1)
 
 	resp, _ := s.app.Test(r, -1)
 	s.Equal(http.StatusInternalServerError, resp.StatusCode)
@@ -168,7 +169,7 @@ func (s *RoleControllerSuite) TestChangeStatusErrSvc() {
 	r.Header.Set("Content-Type", "application/json")
 
 	s.roleRepo.EXPECT().ExistsById(r.Context(), roleId).Return(true, nil).Times(1)
-	s.roleRepo.EXPECT().ChangeStatus(r.Context(), roleId, changeStatus.Enabled).Return(fmt.Errorf(errMessage)).Times(1)
+	s.roleRepo.EXPECT().ChangeStatus(r.Context(), roleId, changeStatus.Enabled).Return(errors.New(errMessage)).Times(1)
 
 	resp, _ := s.app.Test(r, -1)
 	s.Equal(http.StatusInternalServerError, resp.StatusCode)
@@ -208,7 +209,7 @@ func (s *RoleControllerSuite) TestFindByNameErrSvc() {
 	r, _ := http.NewRequest("GET", fmt.Sprintf("/roles/%s", roleName), nil)
 	r.Header.Set("Content-Type", "application/json")
 
-	s.roleRepo.EXPECT().FindByName(r.Context(), roleName).Return(nil, fmt.Errorf(errMessage)).Times(1)
+	s.roleRepo.EXPECT().FindByName(r.Context(), roleName).Return(nil, errors.New(errMessage)).Times(1)
 
 	resp, _ := s.app.Test(r, -1)
 

--- a/src/infra/api/controller/SignupController_test.go
+++ b/src/infra/api/controller/SignupController_test.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"github.com/gofiber/fiber/v2"
 	userMock "github.com/golauth/golauth/src/application/user/mock"
 	"github.com/golauth/golauth/src/domain/entity"
@@ -101,7 +101,7 @@ func (s *SignupControllerSuite) TestCreateUserErrSvc() {
 		Enabled:   true,
 	}
 	errMessage := "could not create new user"
-	s.createUser.EXPECT().Execute(s.ctx, user).Return(nil, fmt.Errorf(errMessage)).Times(1)
+	s.createUser.EXPECT().Execute(s.ctx, user).Return(nil, errors.New(errMessage)).Times(1)
 
 	body, _ := json.Marshal(user)
 	r, _ := http.NewRequest("POST", "/users", strings.NewReader(string(body)))

--- a/src/infra/api/controller/UserController_test.go
+++ b/src/infra/api/controller/UserController_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/gofiber/fiber/v2"
 	"github.com/golauth/golauth/src/application/user/mock"
@@ -108,7 +109,7 @@ func (s *UserControllerSuite) TestFindByIDErrSvc() {
 	r, _ := http.NewRequest("GET", fmt.Sprintf("/users/%s", id), nil)
 	r.Header.Set("Content-Type", "application/json")
 
-	s.findUserById.EXPECT().Execute(r.Context(), id).Return(nil, fmt.Errorf(errMessage)).Times(1)
+	s.findUserById.EXPECT().Execute(r.Context(), id).Return(nil, errors.New(errMessage)).Times(1)
 
 	resp, _ := s.app.Test(r, -1)
 	s.Equal(http.StatusInternalServerError, resp.StatusCode)
@@ -128,7 +129,7 @@ func (s *UserControllerSuite) TestAddRoleErrSvc() {
 	r, _ := http.NewRequest("POST", fmt.Sprintf("/users/%s/add-role", userId), strings.NewReader(string(body)))
 	r.Header.Set("Content-Type", "application/json")
 
-	s.addUserRole.EXPECT().Execute(r.Context(), userId, roleId).Return(fmt.Errorf(errMessage)).Times(1)
+	s.addUserRole.EXPECT().Execute(r.Context(), userId, roleId).Return(errors.New(errMessage)).Times(1)
 
 	resp, err := s.app.Test(r, -1)
 	s.Equal(http.StatusInternalServerError, resp.StatusCode)


### PR DESCRIPTION
This change updates test cases to use errors.New instead of fmt.Errorf for error creation, ensuring consistency and alignment with best practices. Additionally, the Go version has been updated to 1.24, and the Dockerfile has been adjusted accordingly to reflect the updated Go version and Alpine base image.