### PR TITLE
Update workflow to use ubuntu-24.04 for Docker builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   docker:
     name: Build and push Docker image to Docker Hub
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Switching from ubuntu-20.04 to ubuntu-24.04 ensures the workflow uses the latest LTS version with updated tools and security improvements. This change helps maintain compatibility and aligns with current best practices.