### PR TITLE
Update workflow to use ubuntu-24.04 for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache git make \
     && make build
 
 ###
-FROM alpine:2117 AS dist
+FROM alpine:3.21 AS dist
 ENV MIGRATION_SOURCE_URL=./migrations
 
 RUN mkdir /app && addgroup -S golauth && adduser -S golauth -G golauth \


### PR DESCRIPTION
Switching from ubuntu-20.04 to ubuntu-24.04 ensures the workflow uses the latest LTS version with updated tools and security improvements. This change helps maintain compatibility and aligns with current best practices.