### PR TITLE
Remove redundant `version` field from Docker Compose files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ docker run -p 8180:8080 \
 Docker compose example with database creation:
 
 ```yaml
-version: '3'
-
 services:
   postgres:
     image: postgres:alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: postgres:alpine


### PR DESCRIPTION
The `version` field is optional in modern Docker Compose and no longer necessary. This change cleans up the `README.md` example and `docker-compose.yml` file for clarity and adherence to current best practices.